### PR TITLE
Replace deprecated iden function with i.

### DIFF
--- a/qiskit_version/00_Introduction_to_Qiskit.ipynb
+++ b/qiskit_version/00_Introduction_to_Qiskit.ipynb
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, we do not have to add measurements, unless the protocol we are implementing uses a measurement in its internal operation. So we can build a circuit without a measurement and inspect the quantum state directly. With this backend, an empty circuit needs at least an identity operation (`iden`), otherwise a simulation would throw an error."
+    "In this case, we do not have to add measurements, unless the protocol we are implementing uses a measurement in its internal operation. So we can build a circuit without a measurement and inspect the quantum state directly. With this backend, an empty circuit needs at least an identity operation (`i`), otherwise a simulation would throw an error."
    ]
   },
   {
@@ -210,7 +210,7 @@
    "outputs": [],
    "source": [
     "circuit = QuantumCircuit(q, c)\n",
-    "circuit.iden(q[0])\n",
+    "circuit.i(q[0])\n",
     "job = execute(circuit, backend)\n",
     "state = job.result().get_statevector(circuit)\n",
     "print(state)"
@@ -279,7 +279,7 @@
     "from qiskit.tools.visualization import plot_bloch_multivector\n",
     "backend = Aer.get_backend('statevector_simulator')\n",
     "circuit = QuantumCircuit(q, c)\n",
-    "circuit.iden(q[0])\n",
+    "circuit.i(q[0])\n",
     "job = execute(circuit, backend)\n",
     "state = job.result().get_statevector(circuit)\n",
     "print(\"Initial state\")\n",

--- a/qiskit_version/01_Classical_and_Quantum_Probability_Distributions.ipynb
+++ b/qiskit_version/01_Classical_and_Quantum_Probability_Distributions.ipynb
@@ -399,7 +399,7 @@
    "source": [
     "backend_statevector = BasicAer.get_backend('statevector_simulator')\n",
     "circuit = QuantumCircuit(q, c)\n",
-    "circuit.iden(q[0])\n",
+    "circuit.i(q[0])\n",
     "job = execute(circuit, backend_statevector)\n",
     "plot_bloch_multivector(job.result().get_statevector(circuit))"
    ]


### PR DESCRIPTION
As seen in its [documentation](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.iden.html), the `iden` function has been deprecated in favor of the `i` [function](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.i.html), so I replaced all of `iden`'s instances with `i`.